### PR TITLE
For is too eager

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.14 - 31.03.2015
+* AsyncSeq got extracted as separate project and is now a dependency - https://github.com/fsprojects/FSharpx.Async/pull/24 
+
 ### 1.13 - 27.03.2015
 * Renamed to FSharp.Control.AsyncSeq
 * Remove surface area


### PR DESCRIPTION
The "For" combinatory is a bit too eager - it immediately creates an enumerator, when it should do it once each time the resulting AsyncSeq is iterated.