### PR TITLE
Remove extraneous forward slash in iterAsync documentation comment

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -161,7 +161,7 @@ module AsyncSeq =
 
     /// Iterates over the input sequence and calls the specified asynchronous function for
     /// every value. The input sequence will be asked for the next element after 
-    //// the processing of an element completes.
+    /// the processing of an element completes.
     val iterAsync : action:('T -> Async<unit>) -> source:AsyncSeq<'T> -> Async<unit>
 
     /// Returns an asynchronous sequence that returns pairs containing an element


### PR DESCRIPTION
Sorry to waste your time with such a minor PR but the extra forward slash prevents "the processing of an element completes." from being included in the IntelliSense for `iterAsync`. Without this line the documentation reads

>Iterates over the input sequence and calls the specified asynchronous function for every value. The input sequence will be asked for the next element after

Which leaves you wondering when the next element is requested! :smile: