### PR TITLE
fix paket refs

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,8 +1,8 @@
 source https://nuget.org/api/v2
 
 nuget FSharp.Formatting
-nuget NUnit 
-nuget NUnit.Runners
+nuget NUnit 2.6.4
+nuget NUnit.Runners 2.6.4
 nuget FAKE
 nuget SourceLink.Fake
 nuget FSharp.Control.AsyncSeq 1.15.0

--- a/paket.lock
+++ b/paket.lock
@@ -1,27 +1,27 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    FAKE (3.31.4)
-    FSharp.Compiler.Service (0.0.89)
+    FAKE (4.10.3)
+    FSharp.Compiler.Service (1.4.0.6)
     FSharp.Control.AsyncSeq (1.15.0)
-    FSharp.Formatting (2.9.6)
-      FSharp.Compiler.Service (>= 0.0.87)
-      FSharpVSPowerTools.Core (1.8.0)
-    FSharpVSPowerTools.Core (1.8.0)
-      FSharp.Compiler.Service (>= 0.0.87)
+    FSharp.Formatting (2.12.0)
+      FSharp.Compiler.Service (1.4.0.6)
+      FSharpVSPowerTools.Core (2.1.0)
+    FSharpVSPowerTools.Core (2.1.0)
+      FSharp.Compiler.Service (>= 1.4.0.6)
     Microsoft.Bcl (1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
-    Microsoft.Bcl.Build (1.0.21)
+    Microsoft.Bcl.Build (1.0.21) - import_targets: false
     Microsoft.Net.Http (2.2.29)
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
-    Octokit (0.11.0)
+    Octokit (0.16.0)
       Microsoft.Net.Http
-    SourceLink.Fake (0.5.0)
+    SourceLink.Fake (1.1.0)
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (ac46f8ba9cc11bb6e8d02197720697c9e258c0d3)
+    modules/Octokit/Octokit.fsx (917a86046700e4eaaa2aa09de7895e048eaaa1b1)
       Octokit


### PR DESCRIPTION
I'm having trouble building the nuget package, but this gets things a bit further

It's now failing with this (at end of build):

```
Starting Target: NuGet (==> All)
C:\GitHub\dsyme\FSharp.Control.AsyncSeq\.paket\paket.exe pack output "./temp"  v
ersion  2.0.3 releaseNotes  "Fix bug in Async.cache [#33](https://github.com/fsp
rojects/FSharp.Control.AsyncSeq/issues/33)"
Paket version 2.32.5.0
No platform specified; found output path node for the AnyCPU platform after fail
ing to find one for the following:
Paket failed with:
        Could not load file or assembly 'FSharp.Core, Version=4.3.0.0, Culture=n
eutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system
cannot find the file specified.
Running build failed.
Error:
System.Exception: Error during packing ..
   at Fake.Paket.Pack@81.Invoke(String message) in C:\code\fake\src\app\FakeLib\
PaketHelper.fs:line 81
   at Fake.Paket.Pack(FSharpFunc`2 setParams) in C:\code\fake\src\app\FakeLib\Pa
ketHelper.fs:line 81
   at FSI_0001.Build.clo@160-13.Invoke(Unit _arg7) in C:\GitHub\dsyme\FSharp.Con
trol.AsyncSeq\build.fsx:line 161
   at Fake.TargetHelper.runSingleTarget(TargetTemplate`1 target) in C:\code\fake
\src\app\FakeLib\TargetHelper.fs:line 483
```