### PR TITLE
Use Stopwatch instead of DateTime

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -5,6 +5,7 @@
 namespace FSharp.Control
 
 open System
+open System.Diagnostics
 open System.IO
 open System.Collections.Generic
 open System.Threading
@@ -1025,10 +1026,10 @@ module AsyncSeq =
           match rem with
           | Some rem -> async.Return rem
           | None -> Async.StartChildAsTask(ie.MoveNext())
-        let t = DateTime.Now
+        let t = Stopwatch.GetTimestamp()
         let! time = Async.StartChildAsTask(Async.Sleep (max 0 rt))
         let! moveOr = Async.chooseTasks move time
-        let delta = int (DateTime.Now - t).TotalMilliseconds      
+        let delta = int ((Stopwatch.GetTimestamp() - t) * 1000L / Stopwatch.Frequency)
         match moveOr with
         | Choice1Of2 (None, _) -> 
           if buffer.Count > 0 then


### PR DESCRIPTION
`DateTime.Now` is unsuitable for timing of operations, as it relies on the system clock which can be adjusted by the OS for clock drift, NTP sync, or manually by the user.  Additionally, it relies on the local time zone, which might be subject to daylight saving time changes, or (again) changes by the user.

Instead, timing operations (profiling, really) should use `System.Diagnostics.Stopwatch`.

More on this [here](http://codeofmatt.com/2013/04/25/the-case-against-datetime-now/) and [here](http://codeofmatt.com/2015/03/06/common-daylight-saving-time-mistakes-for-net-developers/).

Note that I use the static `GetTimestamp` method instead of instantiating an instance of the `Stopwatch` class.  While both APIs are valid, this one is preferred when there's a potential for multiple instantiation, as the other creates objects on the heap for garbage collection.