### PR TITLE
performance improvements

### DIFF
--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqPerf.fsx
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqPerf.fsx
@@ -30,6 +30,17 @@ N=1000000
 unfoldIter
 Real: 00:00:08.565, CPU: 00:00:08.562, GC gen0: 889, gen1: 2, gen2: 0
 ------------------------------------------------------------------------------------------------------------------------
+-- handcoded unfold
+N=1000000
+
+unfoldIter
+Real: 00:00:08.514, CPU: 00:00:08.562, GC gen0: 890, gen1: 3, gen2: 1
+Real: 00:00:00.878, CPU: 00:00:00.875, GC gen0: 96, gen1: 2, gen2: 0
+
+replicate
+Real: 00:00:01.530, CPU: 00:00:01.531, GC gen0: 156, gen1: 1, gen2: 0
+Real: 00:00:00.926, CPU: 00:00:00.937, GC gen0: 97, gen1: 2, gen2: 0
+------------------------------------------------------------------------------------------------------------------------
 
 *)
 let unfoldIter (N:int) =
@@ -51,5 +62,10 @@ let unfoldChooseIter (N:int) =
   |> AsyncSeq.chooseAsync (Some >> async.Return)
   |> AsyncSeq.iterAsync (ignore >> async.Return)
 
-run unfoldIter
+let replicate (N:int) =
+  AsyncSeq.replicate N ()
+  |> AsyncSeq.iterAsync (ignore >> async.Return)
+
+//run unfoldIter
 //run unfoldChooseIter
+run replicate

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqPerf.fsx
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqPerf.fsx
@@ -20,7 +20,7 @@ let run (test:int -> Async<_>) =
 N=5000
 unfoldIter
 Real: 00:00:03.587, CPU: 00:00:03.578, GC gen0: 346, gen1: 2, gen2: 0
-Real: 00:00:00.095, CPU: 00:00:00.093, GC gen0: 4, gen1: 2, gen2: 0
+Real: 00:00:00.095, CPU: 00:00:00.093, GC gen0: 4, gen1: 2, gen2: 0 (gain due to AsyncGenerator)
 ------------------------------------------------------------------------------------------------------------------------
 N=1000000
 unfoldChooseIter
@@ -35,11 +35,18 @@ N=1000000
 
 unfoldIter
 Real: 00:00:08.514, CPU: 00:00:08.562, GC gen0: 890, gen1: 3, gen2: 1
-Real: 00:00:00.878, CPU: 00:00:00.875, GC gen0: 96, gen1: 2, gen2: 0
+Real: 00:00:00.878, CPU: 00:00:00.875, GC gen0: 96, gen1: 2, gen2: 0 (gain due to hand-coded unfold)
 
 replicate
 Real: 00:00:01.530, CPU: 00:00:01.531, GC gen0: 156, gen1: 1, gen2: 0
 Real: 00:00:00.926, CPU: 00:00:00.937, GC gen0: 97, gen1: 2, gen2: 0
+
+------------------------------------------------------------------------------------------------------------------------
+-- fused unfold (AsyncSeqOp)
+
+unfoldChooseIter
+Real: 00:00:02.979, CPU: 00:00:02.968, GC gen0: 321, gen1: 2, gen2: 0
+Real: 00:00:00.913, CPU: 00:00:00.906, GC gen0: 115, gen1: 2, gen2: 0 (gain due to fused unfold and choose via AsyncSeqOp)
 ------------------------------------------------------------------------------------------------------------------------
 
 *)
@@ -67,5 +74,5 @@ let replicate (N:int) =
   |> AsyncSeq.iterAsync (ignore >> async.Return)
 
 //run unfoldIter
-//run unfoldChooseIter
-run replicate
+run unfoldChooseIter
+//run replicate

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqPerf.fsx
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqPerf.fsx
@@ -1,0 +1,55 @@
+﻿#r @"../../bin/FSharp.Control.AsyncSeq.dll"
+#nowarn "40"
+#time "on"
+
+open System
+open System.Diagnostics
+open FSharp.Control
+
+let N = 1000000
+
+let run (test:int -> Async<_>) =
+  let sw = Stopwatch.StartNew()
+  test N |> Async.RunSynchronously |> ignore
+  sw.Stop()
+
+(*
+
+------------------------------------------------------------------------------------------------------------------------
+-- append generator
+N=5000
+unfoldIter
+Real: 00:00:03.587, CPU: 00:00:03.578, GC gen0: 346, gen1: 2, gen2: 0
+Real: 00:00:00.095, CPU: 00:00:00.093, GC gen0: 4, gen1: 2, gen2: 0
+------------------------------------------------------------------------------------------------------------------------
+N=1000000
+unfoldChooseIter
+Real: 00:00:10.818, CPU: 00:00:10.828, GC gen0: 1114, gen1: 3, gen2: 0
+------------------------------------------------------------------------------------------------------------------------
+N=1000000
+unfoldIter
+Real: 00:00:08.565, CPU: 00:00:08.562, GC gen0: 889, gen1: 2, gen2: 0
+------------------------------------------------------------------------------------------------------------------------
+
+*)
+let unfoldIter (N:int) =
+  let generator state = async {
+    if state < N then
+      return Some (state, state + 1)
+    else
+      return None }
+  AsyncSeq.unfoldAsync generator 0
+  |> AsyncSeq.iterAsync (ignore >> async.Return)
+
+let unfoldChooseIter (N:int) =
+  let generator state = async {
+    if state < N then
+      return Some (state, state + 1)
+    else
+      return None }
+  AsyncSeq.unfoldAsync generator 0
+  |> AsyncSeq.chooseAsync (Some >> async.Return)
+  |> AsyncSeq.iterAsync (ignore >> async.Return)
+
+run unfoldIter
+//run unfoldChooseIter

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -38,6 +38,9 @@ let randomDelayMs (minMs:int) (maxMs:int) (s:AsyncSeq<'a>) =
 let randomDelayDefault (s:AsyncSeq<'a>) =
   randomDelayMs 0 50 s
 
+let randomDelayMax m (s:AsyncSeq<'a>) =
+  randomDelayMs 0 m s
+
 let catch (f:'a -> 'b) : 'a -> Choice<'b, exn> =
   fun a ->
     try f a |> Choice1Of2
@@ -1274,7 +1277,7 @@ let ``AsyncSeq.groupBy should propagate exception and terminate all groups``() =
 
 [<Test>]
 let ``AsyncSeq.combineLatest should behave like merge after initial``() =  
-  for n in 0..20 do
+  for n in 0..10 do
     for m in 0..10 do
       let ls1 = List.init n id
       let ls2 = List.init m id 
@@ -1284,7 +1287,7 @@ let ``AsyncSeq.combineLatest should behave like merge after initial``() =
         if n = 0 || m = 0 then 0
         else (n + m - 1)
       let expected = List.init expectedCount id |> AsyncSeq.ofSeq
-      let actual = AsyncSeq.combineLatestWith (+) (AsyncSeq.ofSeq ls1 |> randomDelayDefault) (AsyncSeq.ofSeq ls2 |> randomDelayDefault)
+      let actual = AsyncSeq.combineLatestWith (+) (AsyncSeq.ofSeq ls1 |> randomDelayMax 2) (AsyncSeq.ofSeq ls2 |> randomDelayMax 2)
       Assert.AreEqual(expected, actual, (sprintf "n=%i m=%i" n m))
 
 [<Test>]

--- a/tests/FSharp.Control.AsyncSeq.Tests/FSharp.Control.AsyncSeq.Tests.fsproj
+++ b/tests/FSharp.Control.AsyncSeq.Tests/FSharp.Control.AsyncSeq.Tests.fsproj
@@ -57,8 +57,9 @@
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
-    <Compile Include="AsyncSeqTests.fs" />
     <None Include="paket.references" />
+    <Compile Include="AsyncSeqTests.fs" />
+    <None Include="AsyncSeqPerf.fsx" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />


### PR DESCRIPTION
This contains performance improvements referenced [here](https://github.com/fsprojects/FSharp.Control.AsyncSeq/issues/50) and [here](https://github.com/fsprojects/FSharp.Control.AsyncSeq/issues/52)

The improvements made were:
- a better append implementation based on the append implementation of `seq<_>`
- fused operations via AsyncSeqOp, which for instance fuse an unfold followed by a choose and a fold into a single instance of an AsyncSeq rather than creating intermediate instances

The latter approach needs to be expanded across other operations. Also, I would like to try a few variations to see if we can get better reuse.


