### PR TITLE
mergeAll max min fairness

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1483,12 +1483,22 @@ module AsyncSeq =
         match !err with 
         | Some e -> e.Throw()
         | None -> ()
-      
+        
     /// Merges all specified async sequences into an async sequence non-deterministically.
     // By moving the last emitted task to the end of the array, this algorithm achieves max-min fairness when merging AsyncSeqs
   let mergeAll (ss:AsyncSeq<'T> list) : AsyncSeq<'T> =
       asyncSeq { 
         let n = ss.Length
+
+        let moveToEnd i (a: 'a[]) =
+          let len = a.Length
+          if i < 0 || i >= len then
+            raise <| System.ArgumentOutOfRangeException()
+          if i <> len-1 then
+            let x = a.[i]
+            System.Array.Copy(a, i+1, a, i, len-1-i)
+            a.[len-1] <- x
+
         if n > 0 then 
           let ies = [| for source in ss -> source.GetEnumerator()  |]
           use _ies = new Disposables<_>(ies)
@@ -1506,8 +1516,8 @@ module AsyncSeq =
                   yield res
                   let! task = Async.StartChildAsTask (ies.[i].MoveNext())
                   do tasks.[i] <- task
-                  System.Array.Copy(tasks, i+1, tasks, i, n-1-i)
-                  tasks.[n-1] <- task
+                  moveToEnd i tasks
+                  moveToEnd i ies
               | None ->
                   let t = System.Threading.Tasks.TaskCompletionSource()
                   tasks.[i] <- t.Task // result never gets set

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -1191,7 +1191,23 @@ let ``Async.mergeAll should perform well``() =
 
     Assert.DoesNotThrow(fun _ -> mergeTest 1000 |> ignore)
 
-
+[<Test>]
+let ``Async.mergeAll should be fair``() =
+  let s1 = asyncSeq {
+    do! Async.Sleep 100
+    yield 1
+  }
+  let s2 = asyncSeq {
+    do! Async.Sleep 10
+    yield 2
+  }
+  let s3 = asyncSeq {
+    yield 3
+  }
+  let actual = AsyncSeq.mergeAll [s1; s2; s3]
+  let expected = [3;2;1] |> AsyncSeq.ofSeq
+  Assert.True(EQ expected actual)
+  
 
 [<Test>]
 let ``AsyncSeq.mergeAll should fail with AggregateException if a task fails``() =

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -1194,11 +1194,11 @@ let ``Async.mergeAll should perform well``() =
 [<Test>]
 let ``Async.mergeAll should be fair``() =
   let s1 = asyncSeq {
-    do! Async.Sleep 100
+    do! Async.Sleep 1000
     yield 1
   }
   let s2 = asyncSeq {
-    do! Async.Sleep 10
+    do! Async.Sleep 100
     yield 2
   }
   let s3 = asyncSeq {


### PR DESCRIPTION
By moving the last emitted task to the end of the array, this algorithm achieves max-min fairness when merging AsyncSeqs