### PR TITLE
Cleanup groupBy logic

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1664,10 +1664,9 @@ module AsyncSeq =
   let groupByAsync (p:'a -> Async<'k>) (s:AsyncSeq<'a>) : AsyncSeq<'k * AsyncSeq<'a>> = asyncSeq {
     let groups = Collections.Generic.Dictionary<'k, Group<'k, 'a>>()
     let close group =
-      groups.Remove(group.key) |> ignore
       AsyncSeqSrcImpl.close group.src
     let closeGroups () =
-      groups.Values |> Seq.toArray |> Array.iter close
+      groups.Values |> Seq.iter close
     use enum = s.GetEnumerator()
     let rec go () = asyncSeq {
       try            

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -6,7 +6,6 @@ namespace FSharp.Control
 
 open System
 open System.Diagnostics
-open System.IO
 open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
@@ -1660,7 +1659,7 @@ module AsyncSeq =
 
   
   let groupByAsync (p:'a -> Async<'k>) (s:AsyncSeq<'a>) : AsyncSeq<'k * AsyncSeq<'a>> = asyncSeq {
-    let groups = Collections.Generic.Dictionary<'k, AsyncSeqSrc< 'a>>()
+    let groups = Dictionary<'k, AsyncSeqSrc< 'a>>()
     let close group =
       AsyncSeqSrcImpl.close group
     let closeGroups () =


### PR DESCRIPTION
There is some logic to remove groups and keep track of the key that at the moment is not necessary.