### PR TITLE
Add truncate as an alias to mimic Seq.

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1286,6 +1286,8 @@ module AsyncSeq =
                   let! moven = ie.MoveNext()
                   b := moven
               else b := None }
+  
+  let truncate count source = take count source
 
   let skip count (source : AsyncSeq<'T>) : AsyncSeq<_> = asyncSeq {
       if (count < 0) then invalidArg "count" "must be non-negative"

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -390,7 +390,11 @@ module AsyncSeq =
     val skipWhile : predicate:('T -> bool) -> source:AsyncSeq<'T> -> AsyncSeq<'T>
 
     /// Returns the first N elements of an asynchronous sequence
+    /// does not cast an exception if count is larger than the sequence length.
     val take : count:int -> source:AsyncSeq<'T> -> AsyncSeq<'T>
+
+    /// Alias for take
+    val truncate : count:int -> source:AsyncSeq<'T> -> AsyncSeq<'T>
 
     /// Skips the first N elements of an asynchronous sequence and
     /// then returns the rest of the sequence unmodified.

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -1389,6 +1389,16 @@ let ``AsyncSeq.take should work``() =
   ()
 
 [<Test>]
+let ``AsyncSeq.truncate should work like take``() =  
+  let s = asyncSeq {
+    yield ["a",1] |> Map.ofList
+  }
+  let expected = s |> AsyncSeq.take 1
+  let actual =  s |> AsyncSeq.truncate 1
+  Assert.AreEqual(expected, actual)
+
+
+[<Test>]
 let ``AsyncSeq.mapAsyncParallel should maintain order`` () =
   for i in 0..100 do
     let ls = List.init i id


### PR DESCRIPTION
Mimic the `Seq.truncate` function. `AsyncSeq.take` behaves like `Seq.truncate` therefore
`AsyncSeq.truncate` should be there for discoverability. Changing `AsyncSeq.take` is a breaking change, but a note that count > lenght is ok should be included at least.