### PR TITLE
Improve parallelism of AsyncSeq.cache

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1059,8 +1059,15 @@ module AsyncSeq =
       }
 
   let cache (source : AsyncSeq<'T>) = 
+    let cacheLock = obj()
     let cache = ResizeArray<_>()
     let fin = TaskCompletionSource<unit>()
+    let tryGetCachedItem i =
+        lock cacheLock (fun() ->
+            if cache.Count > i then
+                Some cache.[i]
+            else
+                None)
     // NB: no need to dispose since we're not using timeouts
     // NB: this MBP might have some unprocessed messages in internal queue until collected
     let mbp = 
@@ -1072,8 +1079,8 @@ module AsyncSeq =
             try
               let! move = ie.MoveNext()
               match move with
-              | Some v -> 
-                cache.Add v
+              | Some v ->
+                lock cacheLock (fun() -> cache.Add v)
               | None -> 
                 fin.SetResult ()
             with ex ->
@@ -1088,15 +1095,21 @@ module AsyncSeq =
     asyncSeq {
       if fin.Task.IsCompleted then yield! ofSeq cache else
       let rec loop i = asyncSeq {
-        let! next = Async.chooseTasks (fin.Task) (mbp.PostAndAsyncReplyTask (fun rep -> (i,rep))) 
-        match next with
-        | Choice2Of2 (Some a,_) ->
-          yield a
-          yield! loop (i + 1)
-        | Choice2Of2 (None,_) -> ()
-        | Choice1Of2 _ ->
-          if i = 0 then yield! ofSeq cache
-          else yield! ofSeq (cache |> Seq.skip i) }
+        let cachedItem = tryGetCachedItem i
+        match cachedItem with
+        | Some a ->
+            yield a
+            yield! loop (i + 1)
+        | None ->
+            let! next = Async.chooseTasks (fin.Task) (mbp.PostAndAsyncReplyTask (fun rep -> (i,rep)))
+            match next with
+            | Choice2Of2 (Some a,_) ->
+              yield a
+              yield! loop (i + 1)
+            | Choice2Of2 (None,_) -> ()
+            | Choice1Of2 _ ->
+              if i = 0 then yield! ofSeq cache
+              else yield! ofSeq (cache |> Seq.skip i) }
       yield! loop 0 }
 
   // --------------------------------------------------------------------------

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1057,7 +1057,7 @@ module AsyncSeq =
             | Observable.Error err -> err.Throw()
             | Observable.Completed -> failwith "unexpected"
       }
-    
+
   let cache (source : AsyncSeq<'T>) = 
     let cache = ResizeArray<_>()
     let fin = TaskCompletionSource<unit>()
@@ -1080,13 +1080,13 @@ module AsyncSeq =
               rep.SetException ex
           if not fin.Task.IsCompleted then
             let a = cache.[i]
-            rep.SetResult (Some a)              
+            rep.SetResult (Some a)
             return! loop ()
           else
             rep.SetResult None }
         return! loop () })
     asyncSeq {
-      if fin.Task.IsCompleted then yield! ofSeq cache else        
+      if fin.Task.IsCompleted then yield! ofSeq cache else
       let rec loop i = asyncSeq {
         let! next = Async.chooseTasks (fin.Task) (mbp.PostAndAsyncReplyTask (fun rep -> (i,rep))) 
         match next with


### PR DESCRIPTION
I noticed that when multiple consumers use a cached AsyncSeq, the late ones delay reading cached items until the lead consumer receives a new item.

This is due to access to cached values going through the mailbox processor. This change adds a test that allows to read a cache value directly if it's there.