### PR TITLE
get reference documentation output from build again

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -138,14 +138,14 @@ Target "PublishNuget" (fun _ ->
 // Generate the documentation
 
 Target "GenerateReferenceDocs" (fun _ ->
-    if not <| executeFSIWithArgs "docs/tools" "generate.fsx" ["--define:RELEASE"; "--define:REFERENCE"] [] then
+    if not <| executeFSIWithArgs "docs/tools" "generate.fsx" ["--define:RELEASE"; "--define:REFERENCE";  "--noframework"] [] then
       failwith "generating reference documentation failed"
 )
 
 let generateHelp' fail debug =
     let args =
-        if debug then ["--define:HELP"]
-        else ["--define:RELEASE"; "--define:HELP"]
+        if debug then ["--define:HELP"; "--noframework"]
+        else ["--define:RELEASE"; "--define:HELP"; "--noframework"]
     if executeFSIWithArgs "docs/tools" "generate.fsx" args [] then
         traceImportant "Help generated"
     else

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -25,6 +25,7 @@ let info =
 #load "../../packages/build/FSharp.Formatting/FSharp.Formatting.fsx"
 #r "../../packages/build/FAKE/tools/NuGet.Core.dll"
 #r "../../packages/build/FAKE/tools/FakeLib.dll"
+#r "../../packages/build/FAKE/tools/FSharp.Core.dll"
 open Fake
 open System.IO
 open Fake.FileHelper
@@ -40,7 +41,11 @@ let root = "file://" + (__SOURCE_DIRECTORY__ @@ "../output")
 #endif
 
 // Paths with template/source/output locations
-let bin        = __SOURCE_DIRECTORY__ @@ "../../bin"
+#if RELEASE
+let bin        = __SOURCE_DIRECTORY__ @@ "../../src/FSharp.Control.AsyncSeq/bin/Release/net45"
+#else
+let bin        = __SOURCE_DIRECTORY__ @@ "../../src/FSharp.Control.AsyncSeq/bin/Debug/net45"
+#endif
 let content    = __SOURCE_DIRECTORY__ @@ "../content"
 let output     = __SOURCE_DIRECTORY__ @@ "../output"
 let files      = __SOURCE_DIRECTORY__ @@ "../files"


### PR DESCRIPTION
Use FSharp.Core.dll shipped in fakebuild nuget package instead for reference documentation generation only #85.

I'm confident this change will not break the CI build as the generate documentation targets are not called.