### PR TITLE
mono build fix attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: csharp
 
 matrix:
   include:
-    - os: linux # Ubuntu 14.04
-      dist: trusty
+    - os: linux 
+      dist: xenial # Ubuntu 16.04 https://docs.travis-ci.com/user/reference/linux/
       sudo: false
       mono: latest
       dotnet: 3.0.100

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
       sudo: false
       mono: latest
       dotnet: 3.0.100
-    - os: osx # OSX 10.12
-      osx_image: xcode9.1
+    - os: osx 
+      osx_image: xcode9.3 # OSX 10.13 https://docs.travis-ci.com/user/reference/osx/#using-macos
       dotnet: 3.0.100
       mono: latest
       sudo: false

--- a/build.fsx
+++ b/build.fsx
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------
 // FAKE build script
 // --------------------------------------------------------------------------------------
 
@@ -78,10 +78,10 @@ Target "AssemblyInfo" (fun _ ->
           Attribute.FileVersion release.AssemblyVersion ]
 
     let getProjectDetails projectPath =
-        let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)
+        let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath: string)
         ( projectPath,
           projectName,
-          System.IO.Path.GetDirectoryName(projectPath),
+          System.IO.Path.GetDirectoryName(projectPath: string),
           (getAssemblyInfoAttributes projectName)
         )
 


### PR DESCRIPTION
Related to:

- [x] mono/mono/issues/8310 - Mono error with introduction of Span type to System.File.IO.Path.GetFileNameWithoutExtension 
- [x] dotnet/core/issues/3148, dotnet/runtime/issues/30346 - dotnet core 3.0 on macOS requires 10.13
- [x] [command sudo apt-get install -qq dotnet-sdk-3.0 failed](https://travis-ci.community/t/not-able-to-install-net-core-3/5562/2) - dotnet core 3.0 on ubuntu requires xenial or bionic (trusty is EOL)