### PR TITLE
Include .fsi files into Fable package path

### DIFF
--- a/src/FSharp.Control.AsyncSeq/FSharp.Control.AsyncSeq.fsproj
+++ b/src/FSharp.Control.AsyncSeq/FSharp.Control.AsyncSeq.fsproj
@@ -23,7 +23,7 @@
     <None Include="paket.template" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="*.fsproj; **\*.fs" PackagePath="fable\" />
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi;" PackagePath="fable\" />
   </ItemGroup>
   <PropertyGroup>
     <NpmDependencies>


### PR DESCRIPTION
Fable compilation currently fails when including this project as the `AsyncSeq.fsi` file is not specified to be copied in `<Content Include="*.fsproj; **\*.fs;" PackagePath="fable\" />`. This pull requests adds .fsi files to the Fable package path, fixing Fable compilation errors.