### PR TITLE
Fix compiling with Fable when targeting netstandard2.1 or netcoreapp3.0

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1747,6 +1747,7 @@ module AsyncSeq =
        }
 
   #if (NETSTANDARD2_1 || NETCOREAPP3_0)
+  #if !FABLE_COMPILER
 
   let ofAsyncEnum (source: Collections.Generic.IAsyncEnumerable<_>) = asyncSeq {
       let! ct = Async.CancellationToken
@@ -1790,7 +1791,6 @@ module AsyncSeq =
   let ofIQueryable (query : IQueryable<'a>) =
      query :?> Collections.Generic.IAsyncEnumerable<'a> |> ofAsyncEnum
 
-  #if !FABLE_COMPILER
   module AsyncSeqSrcImpl =
 
     let private createNode () =


### PR DESCRIPTION
I needed to make my project target netstandard2.1 to use the latest version of FSharp.Control.AsyncSeq, but it no longer compiled with Fable.

The cause is a simple misplaced `#ifdef` in FSharp.Control.AsyncSeq that I fixed in this PR.

There is already an open PR here with that fix, but it's mixed with other things. The author, @alfonsogarciacaro, has been informed (see https://github.com/fable-compiler/Fable/issues/2299#issuecomment-735118635)