### PR TITLE
Sort functions

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1484,19 +1484,19 @@ module AsyncSeq =
           yield buffer.ToArray() }
 
   let toSortedSeq fn source =
-    toArrayAsync source |> Async.map (fun source' -> (fn source' :> seq<'T>)) |> Async.RunSynchronously
+    toArrayAsync source |> Async.map fn |> Async.RunSynchronously
 
-  let sort (source:AsyncSeq<'T>) : seq<'T> when 'T : comparison =
-    toSortedSeq Seq.sort source
+  let sort (source:AsyncSeq<'T>) : array<'T> when 'T : comparison =
+    toSortedSeq Array.sort source
 
-  let sortBy (projection:'T -> 'Key) (source:AsyncSeq<'T>) : seq<'T> when 'Key : comparison =
-    toSortedSeq (Seq.sortBy projection) source
+  let sortBy (projection:'T -> 'Key) (source:AsyncSeq<'T>) : array<'T> when 'Key : comparison =
+    toSortedSeq (Array.sortBy projection) source
 
-  let sortDescending (source:AsyncSeq<'T>) : seq<'T> when 'T : comparison =
-    toSortedSeq Seq.sortDescending source
+  let sortDescending (source:AsyncSeq<'T>) : array<'T> when 'T : comparison =
+    toSortedSeq Array.sortDescending source
 
-  let sortByDescending (projection:'T -> 'Key) (source:AsyncSeq<'T>) : seq<'T> when 'Key : comparison =
-    toSortedSeq (Seq.sortByDescending projection) source
+  let sortByDescending (projection:'T -> 'Key) (source:AsyncSeq<'T>) : array<'T> when 'Key : comparison =
+    toSortedSeq (Array.sortByDescending projection) source
 
   #if !FABLE_COMPILER
   let bufferByCountAndTime (bufferSize:int) (timeoutMs:int) (source:AsyncSeq<'T>) : AsyncSeq<'T[]> =

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1483,32 +1483,20 @@ module AsyncSeq =
       if (buffer.Count > 0) then
           yield buffer.ToArray() }
 
-  let private getEnumerator fn source =
-    toArrayAsync source |> Async.map (fun source' -> (fn source' :> seq<'T>).GetEnumerator())
+  let toSortedSeq fn source =
+    toArrayAsync source |> Async.map (fun source' -> (fn source' :> seq<'T>)) |> Async.RunSynchronously
 
-  let sort (source:AsyncSeq<'T>) : AsyncSeq<'T> when 'T : comparison =  asyncSeq {
-    use! ie = getEnumerator Seq.sort source
-    while ie.MoveNext() do
-      yield ie.Current
-  }
+  let sort (source:AsyncSeq<'T>) : seq<'T> when 'T : comparison =
+    toSortedSeq Seq.sort source
 
-  let sortBy (projection:'T -> 'Key) (source:AsyncSeq<'T>) : AsyncSeq<'T> when 'Key : comparison =  asyncSeq {
-    use! ie = getEnumerator (Seq.sortBy projection) source
-    while ie.MoveNext() do
-      yield ie.Current
-  }
+  let sortBy (projection:'T -> 'Key) (source:AsyncSeq<'T>) : seq<'T> when 'Key : comparison =
+    toSortedSeq (Seq.sortBy projection) source
 
-  let sortDescending (source:AsyncSeq<'T>) : AsyncSeq<'T> when 'T : comparison =  asyncSeq {
-    use! ie = getEnumerator Seq.sortDescending source
-    while ie.MoveNext() do
-      yield ie.Current
-  }
+  let sortDescending (source:AsyncSeq<'T>) : seq<'T> when 'T : comparison =
+    toSortedSeq Seq.sortDescending source
 
-  let sortByDescending (projection:'T -> 'Key) (source:AsyncSeq<'T>) : AsyncSeq<'T> when 'Key : comparison =  asyncSeq {
-    use! ie = getEnumerator (Seq.sortByDescending projection) source
-    while ie.MoveNext() do
-      yield ie.Current
-  }
+  let sortByDescending (projection:'T -> 'Key) (source:AsyncSeq<'T>) : seq<'T> when 'Key : comparison =
+    toSortedSeq (Seq.sortByDescending projection) source
 
   #if !FABLE_COMPILER
   let bufferByCountAndTime (bufferSize:int) (timeoutMs:int) (source:AsyncSeq<'T>) : AsyncSeq<'T[]> =

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -441,25 +441,25 @@ module AsyncSeq =
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sort : source:AsyncSeq<'T> -> seq<'T> when 'T : comparison
+    val sort : source:AsyncSeq<'T> -> array<'T> when 'T : comparison
 
-    /// Applies a key-generating function to each element of an AsyncSeq and yield a sequence ordered by keys.
-    /// This function returns a sequence that digests the whole initial sequence as soon as
+    /// Applies a key-generating function to each element of an AsyncSeq and yield an array ordered by keys.
+    /// This function returns an array that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sortBy : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> seq<'T> when 'Key : comparison
+    val sortBy : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> array<'T> when 'Key : comparison
 
-    /// Yields a sequence ordered descending by keys.
-    /// This function returns a sequence that digests the whole initial sequence as soon as
+    /// Yields an array ordered descending by keys.
+    /// This function returns an array that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sortDescending : source:AsyncSeq<'T> -> seq<'T> when 'T : comparison
+    val sortDescending : source:AsyncSeq<'T> -> array<'T> when 'T : comparison
 
-    /// Applies a key-generating function to each element of an AsyncSeq and yield a sequence ordered descending by keys.
-    /// This function returns a sequence that digests the whole initial sequence as soon as
+    /// Applies a key-generating function to each element of an AsyncSeq and yield an array ordered descending by keys.
+    /// This function returns an array that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sortByDescending : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> seq<'T> when 'Key : comparison
+    val sortByDescending : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> array<'T> when 'Key : comparison
 
     /// Interleaves two async sequences of the same type into a resulting sequence. The provided
     /// sequences are consumed in lock-step.

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -437,25 +437,25 @@ module AsyncSeq =
     /// Flattens an AsyncSeq of asynchronous sequences.
     val concat : AsyncSeq<AsyncSeq<'T>> -> AsyncSeq<'T>
 
-    /// Yields an AsyncSeq ordered by keys.
+    /// Yields a sequence ordered by keys.
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
     val sort : source:AsyncSeq<'T> -> seq<'T> when 'T : comparison
 
-    /// Applies a key-generating function to each element of an AsyncSeq and yield an AsyncSeq ordered by keys.
+    /// Applies a key-generating function to each element of an AsyncSeq and yield a sequence ordered by keys.
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
     val sortBy : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> seq<'T> when 'Key : comparison
 
-    /// Yields a AsyncSeq ordered descending by keys.
+    /// Yields a sequence ordered descending by keys.
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
     val sortDescending : source:AsyncSeq<'T> -> seq<'T> when 'T : comparison
 
-    /// Applies a key-generating function to each element of an AsyncSeq and yield an AsyncSeq ordered descending by keys.
+    /// Applies a key-generating function to each element of an AsyncSeq and yield a sequence ordered descending by keys.
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -437,6 +437,30 @@ module AsyncSeq =
     /// Flattens an AsyncSeq of asynchronous sequences.
     val concat : AsyncSeq<AsyncSeq<'T>> -> AsyncSeq<'T>
 
+    /// Yields an AsyncSeq ordered by keys.
+    /// This function returns a sequence that digests the whole initial sequence as soon as
+    /// that sequence is iterated. As a result this function should not be used with
+    /// large or infinite sequences.
+    val sort : source:AsyncSeq<'T> -> AsyncSeq<'T> when 'T : comparison
+
+    /// Applies a key-generating function to each element of an AsyncSeq and yield an AsyncSeq ordered by keys.
+    /// This function returns a sequence that digests the whole initial sequence as soon as
+    /// that sequence is iterated. As a result this function should not be used with
+    /// large or infinite sequences.
+    val sortBy : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> AsyncSeq<'T> when 'Key : comparison
+
+    /// Yields a AsyncSeq ordered descending by keys.
+    /// This function returns a sequence that digests the whole initial sequence as soon as
+    /// that sequence is iterated. As a result this function should not be used with
+    /// large or infinite sequences.
+    val sortDescending : source:AsyncSeq<'T> -> AsyncSeq<'T> when 'T : comparison
+
+    /// Applies a key-generating function to each element of an AsyncSeq and yield an AsyncSeq ordered descending by keys.
+    /// This function returns a sequence that digests the whole initial sequence as soon as
+    /// that sequence is iterated. As a result this function should not be used with
+    /// large or infinite sequences.
+    val sortByDescending : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> AsyncSeq<'T> when 'Key : comparison
+
     /// Interleaves two async sequences of the same type into a resulting sequence. The provided
     /// sequences are consumed in lock-step.
     val interleave : source1:AsyncSeq<'T> -> source2:AsyncSeq<'T> -> AsyncSeq<'T>
@@ -452,7 +476,7 @@ module AsyncSeq =
     #if !FABLE_COMPILER
     /// Buffer items from the async sequence until a specified buffer size is reached or a specified amount of time is elapsed.
     val bufferByCountAndTime : bufferSize:int -> timeoutMs:int -> source:AsyncSeq<'T> -> AsyncSeq<'T []>
-    
+
     /// Buffers items from the async sequence by the specified time interval.
     /// If no items are received in an intervel and empty array is emitted.
     val bufferByTime : timeMs:int -> source:AsyncSeq<'T> -> AsyncSeq<'T[]>
@@ -490,7 +514,7 @@ module AsyncSeq =
     /// but in parallel, without waiting for a prior mapping operation to complete.
     /// Parallelism is bound by the ThreadPool.
     val mapAsyncParallel : mapping:('T -> Async<'U>) -> s:AsyncSeq<'T> -> AsyncSeq<'U>
-    
+
     /// Applies a key-generating function to each element and returns an async sequence containing unique keys
     /// and async sequences containing elements corresponding to the key.
     ///
@@ -504,7 +528,7 @@ module AsyncSeq =
     /// Note that the resulting async sequence has to be processed in parallel (e.g AsyncSeq.mapAsyncParallel) becaused
     /// completion of sub-sequences depends on completion of other sub-sequences.
     val groupBy<'T, 'Key when 'Key : equality> : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> AsyncSeq<'Key * AsyncSeq<'T>>
-    
+
     #if (NETSTANDARD2_1 || NETCOREAPP3_0)
 
     /// Creates an asynchronous computation that asynchronously yields results from the provided .NET IAsyncEnumerable.

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -441,25 +441,25 @@ module AsyncSeq =
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sort : source:AsyncSeq<'T> -> AsyncSeq<'T> when 'T : comparison
+    val sort : source:AsyncSeq<'T> -> seq<'T> when 'T : comparison
 
     /// Applies a key-generating function to each element of an AsyncSeq and yield an AsyncSeq ordered by keys.
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sortBy : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> AsyncSeq<'T> when 'Key : comparison
+    val sortBy : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> seq<'T> when 'Key : comparison
 
     /// Yields a AsyncSeq ordered descending by keys.
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sortDescending : source:AsyncSeq<'T> -> AsyncSeq<'T> when 'T : comparison
+    val sortDescending : source:AsyncSeq<'T> -> seq<'T> when 'T : comparison
 
     /// Applies a key-generating function to each element of an AsyncSeq and yield an AsyncSeq ordered descending by keys.
     /// This function returns a sequence that digests the whole initial sequence as soon as
     /// that sequence is iterated. As a result this function should not be used with
     /// large or infinite sequences.
-    val sortByDescending : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> AsyncSeq<'T> when 'Key : comparison
+    val sortByDescending : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> seq<'T> when 'Key : comparison
 
     /// Interleaves two async sequences of the same type into a resulting sequence. The provided
     /// sequences are consumed in lock-step.

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -1736,14 +1736,14 @@ let ``Async.concat should work``() =
 [<Test>]
 let ``AsyncSeq.sort should work for``() =
   let input = [1; 3; 2; 5; 7; 4; 6] |> AsyncSeq.ofSeq
-  let expected = [1..7]
+  let expected = [|1..7|]
   let actual = input |> AsyncSeq.sort
   Assert.AreEqual(expected, actual)
 
 [<Test>]
 let ``AsyncSeq.sortDescending should work``() =
   let input = [1; 3; 2; Int32.MaxValue; 4; 6; Int32.MinValue; 5; 7; 0] |> AsyncSeq.ofSeq
-  let expected = seq { yield Int32.MaxValue; yield! seq{ 7..-1..0 }; yield Int32.MinValue }
+  let expected = seq { yield Int32.MaxValue; yield! seq{ 7..-1..0 }; yield Int32.MinValue } |> Array.ofSeq
   let actual = input |> AsyncSeq.sortDescending
   Assert.AreEqual(expected, actual)
 
@@ -1751,7 +1751,7 @@ let ``AsyncSeq.sortDescending should work``() =
 let ``AsyncSeq.sortBy should work``() =
   let fn x = Math.Abs(x-5)
   let input = [1; 2; 4; 5; 7] |> AsyncSeq.ofSeq
-  let expected = [5; 4; 7; 2; 1]
+  let expected = [|5; 4; 7; 2; 1|]
   let actual = input |> AsyncSeq.sortBy fn
   Assert.AreEqual(expected, actual)
 
@@ -1759,7 +1759,7 @@ let ``AsyncSeq.sortBy should work``() =
 let ``AsyncSeq.sortByDescending should work``() =
   let fn x = Math.Abs(x-5)
   let input = [1; 2; 4; 5; 6; 7;] |> AsyncSeq.ofSeq
-  let expected = [1; 2; 7; 4; 6; 5;]
+  let expected = [|1; 2; 7; 4; 6; 5;|]
   let actual = input |> AsyncSeq.sortByDescending fn
   Assert.AreEqual(expected, actual)
 

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -1512,18 +1512,18 @@ let ``AsyncSeq.iterAsyncParallel should propagate exception`` () =
 
 [<Test>]
 let ``AsyncSeq.iterAsyncParallel should cancel and not block forever when run in parallel with another exception-throwing Async`` () =
-    
+
     let handle x = async {
-           do! Async.Sleep 50           
+           do! Async.Sleep 50
     }
 
-    let fakeAsync = async {    
+    let fakeAsync = async {
            do! Async.Sleep 500
            return "fakeAsync"
     }
 
     let makeAsyncSeqBatch () =
-           let rec loop() = asyncSeq {            
+           let rec loop() = asyncSeq {
                let! batch =  fakeAsync |> Async.Catch
                match batch with
                | Choice1Of2 batch ->
@@ -1532,11 +1532,11 @@ let ``AsyncSeq.iterAsyncParallel should cancel and not block forever when run in
                    yield! loop()
                  else
                    yield batch
-                   yield! loop() 
+                   yield! loop()
                | Choice2Of2 err ->
                     printfn "Problem getting batch: %A" err
            }
-       
+
            loop()
 
     let x = makeAsyncSeqBatch () |> AsyncSeq.concatSeq |> AsyncSeq.iterAsyncParallel handle
@@ -1733,6 +1733,36 @@ let ``Async.concat should work``() =
 
       Assert.True(EQ expected actual)
 
+[<Test>]
+let ``AsyncSeq.sort should work for``() =
+  let input = [1; 3; 2; 5; 7; 4; 6] |> AsyncSeq.ofSeq
+  let expected = [1..7] |> AsyncSeq.ofSeq
+  let actual = input |> AsyncSeq.sort
+  Assert.AreEqual(expected, actual)
+
+[<Test>]
+let ``AsyncSeq.sortDescending should work``() =
+  let input = [1; 3; 2; Int32.MaxValue; 4; 6; Int32.MinValue; 5; 7; 0] |> AsyncSeq.ofSeq
+  let expected = seq { yield Int32.MaxValue; yield! seq{ 7..-1..0 }; yield Int32.MinValue } |> AsyncSeq.ofSeq
+  let actual = input |> AsyncSeq.sortDescending
+  Assert.AreEqual(expected, actual)
+
+[<Test>]
+let ``AsyncSeq.sortBy should work``() =
+  let fn x = Math.Abs(x-5)
+  let input = [1; 2; 4; 5; 7] |> AsyncSeq.ofSeq
+  let expected = [5; 4; 7; 2; 1] |> AsyncSeq.ofSeq
+  let actual = input |> AsyncSeq.sortBy fn
+  Assert.AreEqual(expected, actual)
+
+[<Test>]
+let ``AsyncSeq.sortByDescending should work``() =
+  let fn x = Math.Abs(x-5)
+  let input = [1; 2; 4; 5; 6; 7;] |> AsyncSeq.ofSeq
+  let expected = [1; 2; 7; 4; 6; 5;] |> AsyncSeq.ofSeq
+  let actual = input |> AsyncSeq.sortByDescending fn
+  Assert.AreEqual(expected, actual)
+
 #if (NETSTANDARD2_1 || NETCOREAPP3_0)
 [<Test>]
 let ``AsyncSeq.ofAsyncEnum should roundtrip successfully``() =
@@ -1744,8 +1774,8 @@ let ``AsyncSeq.ofAsyncEnum should roundtrip successfully``() =
 let ``AsyncSeq.toAsyncEnum raises exception``() : unit =
   async {
     let exceptionMessage = "Raised inside AsyncSeq"
-    let exceptionSequence = 
-      asyncSeq { yield failwith exceptionMessage; yield 1 } 
+    let exceptionSequence =
+      asyncSeq { yield failwith exceptionMessage; yield 1 }
       |> AsyncSeq.toAsyncEnum
     let mutable exceptionRaised = false
     try
@@ -1765,9 +1795,9 @@ let ``AsyncSeq.toAsyncEnum raises exception``() : unit =
 let ``AsyncSeq.ofAsyncEnum raises exception``() : unit =
   async {
     let exceptionMessage = "Raised inside AsyncSeq"
-    let exceptionSequence = 
-      asyncSeq { yield failwith exceptionMessage; yield 1 } 
-      |> AsyncSeq.toAsyncEnum 
+    let exceptionSequence =
+      asyncSeq { yield failwith exceptionMessage; yield 1 }
+      |> AsyncSeq.toAsyncEnum
       |> AsyncSeq.ofAsyncEnum
     let mutable exceptionRaised = false
     try

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -1736,14 +1736,14 @@ let ``Async.concat should work``() =
 [<Test>]
 let ``AsyncSeq.sort should work for``() =
   let input = [1; 3; 2; 5; 7; 4; 6] |> AsyncSeq.ofSeq
-  let expected = [1..7] |> AsyncSeq.ofSeq
+  let expected = [1..7]
   let actual = input |> AsyncSeq.sort
   Assert.AreEqual(expected, actual)
 
 [<Test>]
 let ``AsyncSeq.sortDescending should work``() =
   let input = [1; 3; 2; Int32.MaxValue; 4; 6; Int32.MinValue; 5; 7; 0] |> AsyncSeq.ofSeq
-  let expected = seq { yield Int32.MaxValue; yield! seq{ 7..-1..0 }; yield Int32.MinValue } |> AsyncSeq.ofSeq
+  let expected = seq { yield Int32.MaxValue; yield! seq{ 7..-1..0 }; yield Int32.MinValue }
   let actual = input |> AsyncSeq.sortDescending
   Assert.AreEqual(expected, actual)
 
@@ -1751,7 +1751,7 @@ let ``AsyncSeq.sortDescending should work``() =
 let ``AsyncSeq.sortBy should work``() =
   let fn x = Math.Abs(x-5)
   let input = [1; 2; 4; 5; 7] |> AsyncSeq.ofSeq
-  let expected = [5; 4; 7; 2; 1] |> AsyncSeq.ofSeq
+  let expected = [5; 4; 7; 2; 1]
   let actual = input |> AsyncSeq.sortBy fn
   Assert.AreEqual(expected, actual)
 
@@ -1759,7 +1759,7 @@ let ``AsyncSeq.sortBy should work``() =
 let ``AsyncSeq.sortByDescending should work``() =
   let fn x = Math.Abs(x-5)
   let input = [1; 2; 4; 5; 6; 7;] |> AsyncSeq.ofSeq
-  let expected = [1; 2; 7; 4; 6; 5;] |> AsyncSeq.ofSeq
+  let expected = [1; 2; 7; 4; 6; 5;]
   let actual = input |> AsyncSeq.sortByDescending fn
   Assert.AreEqual(expected, actual)
 


### PR DESCRIPTION
This PR implements `sort`, `sortBy`, `sortDescending` and `sortByDescending` functions and addresses the issue/feature request #126 

I have assumed that `AsyncSeq` is more about asynchronous nature of the type than the infinite nature of it. Therefore, I have implemented these using `Seq.sort`, `Seq.sortBy`, `Seq.sortDescending` and `Seq.sortByDescending` i.e. I have not considered implementing some sort of time-windowed sorting feature. Like their `Seq` counterparts, these functions are not intended to be used in large or infinite sequences.

In terms of unit testing, I have added just a test each for testing integer sequences. This feels like a good usecase for property-based testing using a framework like `FsCheck` but I haven't seen any property-based tests here so decided not to bother. Please let me know if  you think introducing property-based tests would add value to this repo and I will bring in `FsCheck` and add some more tests for the above functions.

Thank you 🙂

