### PR TITLE
Add AsyncSeq.head and AsyncSeq.tail

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1344,6 +1344,13 @@ module AsyncSeq =
           let! moven = ie.MoveNext()
           b := moven }
 
+  let head (source : AsyncSeq<'T>) = async {
+      match! tryFirst source with
+      | Some x -> return x
+      | None -> return invalidArg (nameof source) "The input sequence was empty." }
+
+  let tail (source: AsyncSeq<'T>) = skip 1 source
+
   let toArrayAsync (source : AsyncSeq<'T>) : Async<'T[]> = async {
       let ra = (new ResizeArray<_>())
       use ie = source.GetEnumerator()

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -417,6 +417,13 @@ module AsyncSeq =
     /// then returns the rest of the sequence unmodified.
     val skip : count:int -> source:AsyncSeq<'T> -> AsyncSeq<'T>
 
+    /// Returns the first element of the asynchronous sequence
+    val head : source:AsyncSeq<'T> -> Async<'T>
+
+    /// Returns an asynchronous sequence that skips 1 element of the underlying
+    /// sequence and then yields the remaining elements of the sequence.
+    val tail : source:AsyncSeq<'T> -> AsyncSeq<'T>
+
     /// Creates an async computation which iterates the AsyncSeq and collects the output into an array.
     val toArrayAsync : source:AsyncSeq<'T> -> Async<'T []>
 


### PR DESCRIPTION
Hello!

Regular `Seq` contains simple convenience functions `head` and `tail`. I implemented those for `AsyncSeq`, maybe they could be added?

Thanks.