### PR TITLE
Fix Nuget package license link

### DIFF
--- a/src/FSharp.Control.AsyncSeq/FSharp.Control.AsyncSeq.fsproj
+++ b/src/FSharp.Control.AsyncSeq/FSharp.Control.AsyncSeq.fsproj
@@ -5,7 +5,7 @@
     <Summary>Asynchronous sequences for F#</Summary>
     <Description>Asynchronous sequences for F#</Description>
     <Copyright>Copyright 2017</Copyright>
-    <PackageLicenseUrl>https://fsprojects.github.io/FSharp.Control.AsyncSeq/license.html</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/fsprojects/FSharp.Control.AsyncSeq/blob/main/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://fsprojects.github.io/FSharp.Control.AsyncSeq/</PackageProjectUrl>
     <PackageIconUrl>https://fsprojects.github.io/FSharp.Control.AsyncSeq/img/logo.png</PackageIconUrl>
     <PackageTags>F#;async;fsharp;streaming</PackageTags>


### PR DESCRIPTION
Related to #168

Update the Nuget package license link to fix the 404 error.

* Change the `PackageLicenseUrl` in `src/FSharp.Control.AsyncSeq/FSharp.Control.AsyncSeq.fsproj` to `https://github.com/fsprojects/FSharp.Control.AsyncSeq/blob/main/LICENSE.md`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fsprojects/FSharp.Control.AsyncSeq/issues/168?shareId=b884215d-24fb-4ad2-8c58-ccb5c151a045).