### PR TITLE
feature/interleave-many

### DIFF
--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fs
@@ -1396,6 +1396,11 @@ module AsyncSeq =
   let interleave (source1:AsyncSeq<'T>) (source2:AsyncSeq<'T>) : AsyncSeq<'T> =
     interleaveChoice source1 source2 |> map (function Choice1Of2 x -> x | Choice2Of2 x -> x)
 
+  let interleaveMany (xs : #seq<AsyncSeq<'T>>) : AsyncSeq<'T> =
+    let mutable result = empty
+    for x in xs do
+      result <- interleave result x
+    result
 
   let bufferByCount (bufferSize:int) (source:AsyncSeq<'T>) : AsyncSeq<'T[]> =
     if (bufferSize < 1) then invalidArg "bufferSize" "must be positive"

--- a/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
+++ b/src/FSharp.Control.AsyncSeq/AsyncSeq.fsi
@@ -462,10 +462,14 @@ module AsyncSeq =
     /// large or infinite sequences.
     val sortByDescending : projection:('T -> 'Key) -> source:AsyncSeq<'T> -> array<'T> when 'Key : comparison
     #endif
-    
+
     /// Interleaves two async sequences of the same type into a resulting sequence. The provided
     /// sequences are consumed in lock-step.
     val interleave : source1:AsyncSeq<'T> -> source2:AsyncSeq<'T> -> AsyncSeq<'T>
+
+    /// Interleaves a sequence of async sequences into a resulting async sequence. The provided
+    /// sequences are consumed in lock-step.
+    val interleaveMany : source:#seq<AsyncSeq<'T>> -> AsyncSeq<'T>
 
     /// Interleaves two async sequences into a resulting sequence. The provided
     /// sequences are consumed in lock-step.

--- a/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Control.AsyncSeq.Tests/AsyncSeqTests.fs
@@ -407,6 +407,25 @@ let ``AsyncSeq.interleave first empty``() =
   let merged = AsyncSeq.interleave s1 s2 |> AsyncSeq.toListSynchronously
   Assert.True([1 ; 2 ; 3] = merged)
 
+[<Test>]
+let ``AsyncSeq.interleaveMany empty``() =
+  let merged = AsyncSeq.interleaveMany [] |> AsyncSeq.toListSynchronously
+  Assert.True(List.isEmpty merged)
+
+[<Test>]
+let ``AsyncSeq.interleaveMany 1``() =
+  let s1 = AsyncSeq.ofSeq ["a";"b";"c"]
+  let merged = AsyncSeq.interleaveMany [s1] |> AsyncSeq.toListSynchronously
+  Assert.True(["a" ; "b" ; "c" ] = merged)
+
+[<Test>]
+let ``AsyncSeq.interleaveMany 3``() =
+  let s1 = AsyncSeq.ofSeq ["a";"b"]
+  let s2 = AsyncSeq.ofSeq ["i";"j";"k";"l"]
+  let s3 = AsyncSeq.ofSeq ["x";"y";"z"]
+  let merged = AsyncSeq.interleaveMany [s1;s2;s3] |> AsyncSeq.toListSynchronously
+  Assert.True(["a"; "x"; "i"; "y"; "b"; "z"; "j"; "k"; "l"] = merged)
+
 
 [<Test>]
 let ``AsyncSeq.bufferByCount``() =


### PR DESCRIPTION
Add `AsyncSeq.interleaveMany` and tests.

The implementation uses `mutate` internally instead of a fold for efficiency. 