### PR TITLE
[Repo Assist] CI: upgrade GitHub Actions — checkout v4, setup-node v4, Node 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4.3.1
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4.3.1
       with:
         dotnet-version: '8.0.x'
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2.4.0
+      uses: actions/setup-node@v4
       with:
-        node-version: 14.17.*
+        node-version: '20'
     - name: Install tools
       run: dotnet tool restore
     - name: Build and Test


### PR DESCRIPTION
- actions/checkout@v2 → @v4: picks up performance/security improvements
  and works correctly with modern runners
- actions/setup-node@v2.4.0 → @v4 in pull-request.yml
- Node.js 14.17.* → '20': Node 14 reached end-of-life in April 2023;
  Node 20 is the current LTS release
- actions/checkout@v2 → @v4 in publish.yml

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
